### PR TITLE
Add support for Windows four-digit year format

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Change history for HTTP-Date
     - Use copyright year rather than range (GH#18) (Olaf Alders)
     - Replace "Test" with "Test::More" (GH#20) (James Raspass)
     - Remove the executable bit from the test (GH#21) (James Raspass)
+    - Add support for Windows four-digit year format (Grant Street Group)
 
 6.05      2019-11-19 03:02:32Z
     - Bump minimum version of Time::Local to 1.28 (GH#17) (Olaf Alders)

--- a/lib/HTTP/Date.pm
+++ b/lib/HTTP/Date.pm
@@ -179,7 +179,7 @@ sub parse_date ($) {
 
         ||
 
-        # Windows 'dir' 11-12-96  03:52PM
+        # Windows 'dir': '11-12-96  03:52PM' and four-digit year variant
         (
         ( $mon, $day, $yr, $hr, $min, $ampm )
         = /^
@@ -187,7 +187,7 @@ sub parse_date ($) {
              -
           (\d{2})                # day
              -
-          (\d{2})                # year
+          (\d{2,4})              # year
              \s+
           (\d\d?):(\d\d)([APap][Mm])  # hour:min AM or PM
              \s*$
@@ -365,7 +365,8 @@ The function is able to parse the following formats:
  "Feb  3  1994"      -- Unix 'ls -l' format
  "Feb  3 17:03"      -- Unix 'ls -l' format
 
- "11-15-96  03:52PM" -- Windows 'dir' format
+ "11-15-96  03:52PM"   -- Windows 'dir' format
+ "11-15-1996  03:52PM" -- Windows 'dir' format with four-digit year
 
 The parser ignores leading and trailing whitespace.  It also allow the
 seconds to be missing and the month to be numerical in most formats.

--- a/t/date.t
+++ b/t/date.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 135;
+use Test::More tests => 141;
 use HTTP::Date;
 
 # test str2time for supported dates.  Test cases with 2 digit year
@@ -35,6 +35,7 @@ my (@tests) = (
     'Feb  3 1994',    # Unix 'ls -l' format
 
     "02-03-94  12:00AM",    # Windows 'dir' format
+    "02-03-1994  12:00AM",  # Windows 'dir' format with four-digit year
 
     # ISO 8601 formats
     '1994-02-03 00:00:00 +0000',
@@ -156,6 +157,15 @@ is( $t, "1996-11-12 13:05:00" );
 
 $t = time2iso( str2time("11-12-96 12:05PM") );
 is( $t, "1996-11-12 12:05:00" );
+
+$t = time2iso( str2time("11-12-01 12:00PM") );
+is( $t, "2001-11-12 12:00:00" );
+
+$t = time2iso( str2time("11-12-1996 12:00AM") );
+is( $t, "1996-11-12 00:00:00" );
+
+$t = time2iso( str2time("11-12-2022 12:00AM") );
+is( $t, "2022-11-12 00:00:00" );
 
 $t = str2time("2000-01-01 00:00:01.234");
 note "FRAC $t = ", time2iso($t);


### PR DESCRIPTION
This date format has been an option available in the Windows Server FTP service since at least 2012, and possibly elsewhere.