### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to keep GitHub Actions up to date.

- **Two groups** for the `github-actions` ecosystem:
  - `major-updates` — batches coordinated major bumps (e.g. `upload-artifact`/`download-artifact`) so paired releases land atomically
  - `minor-and-patch` — a single rolling PR for routine minor/patch bumps
- **7-day cooldown** (`default-days: 7`) so a broken release can be yanked or patched before a PR opens
- Weekly schedule

## Notes

Generated via the `tune-dependabot-config` skill. No prior config existed; this is GitHub-Actions-only since the dist has no other tracked package manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)