### PR TITLE
Tune Perl CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,10 @@ on:
       - "*"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-job:
     name: Build distribution

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -100,9 +100,9 @@ jobs:
         with:
           name: build_dir
           path: .
-      - name: install deps using cpm
-        uses: perl-actions/install-with-cpm@v2
+      - uses: perl-actions/setup-cpm@v1
         with:
-          cpanfile: "cpanfile"
-          args: "--with-suggests --with-recommends --with-test"
+          version: compat
+      - name: install deps using cpm
+        run: cpm install -g --cpanfile cpanfile --with-suggests --with-recommends --with-test
       - run: prove -lr t

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,6 +67,9 @@ jobs:
           - "5.32"
           - "5.34"
           - "5.36"
+          - "5.38"
+          - "5.40"
+          - "5.42"
         exclude:
           - os: windows-latest
             perl-version: "5.8"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,6 +48,7 @@ jobs:
     needs: build-job
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         perl-version:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester:5.36
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v7
       - name: Run Tests
@@ -33,7 +33,7 @@ jobs:
     needs: build-job
     runs-on: ubuntu-latest
     container:
-      image: perldocker/perl-tester:5.36
+      image: perldocker/perl-tester:5.42
     steps:
       - uses: actions/checkout@v7 # codecov wants to be inside a Git repository
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
Modernizes `.github/workflows/build-and-test.yml` via the `tune-perl-ci` transforms, each landed as its own revertable commit.

## Changes
- **Disable fail-fast** on matrix jobs so one failing Perl/OS cell doesn't mask the rest of the matrix.
- **Extend Linux + macOS matrices through Perl 5.42** (adds 5.36/5.38/5.40/5.42 where missing).
- **Bump build/coverage containers** to `perldocker/perl-tester:5.42` (literal-tag images only; matrix-variable tags left alone).
- **Add a workflow-level `concurrency:` block** to cancel superseded runs on the same ref.
- **Install deps with `setup-cpm@v1` + an explicit `cpm install` run step**, replacing the `install-with-cpm` composite step (drops `sudo:`, uses `version: compat` for per-Perl cpm selection).

## Not applied
- **Restrict push trigger** — already conformant (`on.push.branches` was already `["master"]`).
- **Drop pre-5.24 macOS/Windows cells** — skipped: `test-job` uses a mixed `matrix.os: [ubuntu, macos, windows]`, where trimming a `perl-version` entry would also drop the Linux cell. Use an explicit `matrix.exclude:` block if per-OS trimming is desired.

Also includes the earlier Dependabot config + major-updates bump commits already on this branch.

Each transform's edit was verified with a YAML parse plus a structural assertion before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)