### PR TITLE
Reject malformed ISO 8601 timezone with a doubled colon

### DIFF
--- a/lib/HTTP/Date.pm
+++ b/lib/HTTP/Date.pm
@@ -171,7 +171,7 @@ sub parse_date ($) {
         (?::?([0-9][0-9](?:\.[0-9]*)?))?  # optional seconds (and fractional)
      )?                    # optional clock
         \s*
-     ([-+]?[0-9][0-9]?:?(:?[0-9][0-9])?
+     ([-+]?[0-9][0-9]?:?(?:[0-9][0-9])?
       |Z|z)?               # timezone  (Z is "zero meridian", i.e. GMT)
         \s*$
     /x

--- a/t/date.t
+++ b/t/date.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 152;
+use Test::More tests => 156;
 use HTTP::Date;
 
 # test str2time for supported dates.  Test cases with 2 digit year
@@ -197,6 +197,17 @@ use HTTP::Date qw(parse_date);
 
 my @d = parse_date("Jan 1 2001");
 is_deeply( \@d, [2001, 1, 1, 0, 0, 0, undef] );
+
+# A malformed timezone with a doubled colon must be rejected, not silently
+# captured as the timezone. RT #101378 / GH #7.
+is_deeply( [ parse_date("1996-02-29 12:00:00 -01::00") ],
+    [], 'malformed timezone -01::00 is rejected' );
+
+# Well-formed timezone variants must still parse, returning the timezone intact.
+for my $tz ('-01:00', '-0100', '-01') {
+    my @d = parse_date("1996-02-29 12:00:00 $tz");
+    is( $d[6], $tz, "timezone $tz still accepted" );
+}
 
 # This test will break around year 2070
 is( parse_date("03-Feb-20"), "2020-02-03 00:00:00" );


### PR DESCRIPTION
Closes #7

## Problem
`parse_date` accepted a malformed ISO 8601 timezone such as `1996-02-29 12:00:00 -01::00` and returned the bad string `-01::00` verbatim as the timezone field.

## Cause
The timezone sub-pattern used a capturing group `(:?[0-9][0-9])` where a non-capturing group `(?:[0-9][0-9])` was intended — the `:` and `?` were transposed. The stray inner `:?` let a second colon be consumed, so a doubled colon slipped through.

## Fix
Use a non-capturing group `(?:[0-9][0-9])` so the colon separator is matched only by the outer `:?`. Well-formed offsets (`-01:00`, `-0100`, `-01`, `Z`) are unaffected.

## Testing
- Added a regression test asserting `parse_date("...-01::00")` returns an empty list; verified it fails on the pre-fix code and passes with the fix.
- Added positive tests confirming `-01:00`, `-0100`, and `-01` still parse with the timezone returned intact.
- Full suite passes (172 tests).